### PR TITLE
scipy 1.14 and numpy 2 backward comp.

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ computations.
 What's new?
 -----------
 
+* [June 26, 2024] Dropping support for Python <= 3.8 (due to HDF5 modules). Minor updates for Scipy 1.14.0 and Numpy 2.0
 * [November 22, 2021] new filters, SVO interface, automated tests and documentation.
 * [November 6, 2019] astropy version available in beta (`from pyphot import astropy as pyphot`)
 * [April 29, 2019] sandbox contains fully unit aware passbands and lick indices libraries

--- a/pyphot/astropy/sandbox.py
+++ b/pyphot/astropy/sandbox.py
@@ -26,7 +26,7 @@ import tables
 try:
     from scipy.integrate import trapezoid
 except ImportError:  # older scipy / numpy < 2.0
-    from scipy integrate import trapz as trapezoid
+    from scipy.integrate import trapz as trapezoid
 
 from .simpletable import SimpleTable
 from .vega import Vega

--- a/pyphot/astropy/sandbox.py
+++ b/pyphot/astropy/sandbox.py
@@ -23,7 +23,10 @@ import os
 from functools import wraps
 import numpy as np
 import tables
-from scipy.integrate import trapezoid
+try:
+    from scipy.integrate import trapezoid
+except ImportError:  # older scipy / numpy < 2.0
+    from scipy integrate import trapz as trapezoid
 
 from .simpletable import SimpleTable
 from .vega import Vega

--- a/pyphot/phot.py
+++ b/pyphot/phot.py
@@ -17,7 +17,12 @@ This also include functions to keep libraries up to date
 from __future__ import print_function, division
 import numpy as np
 import tables
-from scipy.integrate import trapezoid
+
+try:
+    from scipy.integrate import trapezoid
+except ImportError:  # older scipy / numpy < 2.0
+    from scipy integrate import trapz as trapezoid
+    
 from functools import wraps
 
 from .simpletable import SimpleTable

--- a/pyphot/phot.py
+++ b/pyphot/phot.py
@@ -21,7 +21,7 @@ import tables
 try:
     from scipy.integrate import trapezoid
 except ImportError:  # older scipy / numpy < 2.0
-    from scipy integrate import trapz as trapezoid
+    from scipy.integrate import trapz as trapezoid
     
 from functools import wraps
 

--- a/pyphot/sandbox.py
+++ b/pyphot/sandbox.py
@@ -26,7 +26,7 @@ import tables
 try:
     from scipy.integrate import trapezoid
 except ImportError:  # older scipy / numpy < 2.0
-    from scipy integrate import trapz as trapezoid
+    from scipy.integrate import trapz as trapezoid
 
 from .simpletable import SimpleTable
 from .vega import Vega

--- a/pyphot/sandbox.py
+++ b/pyphot/sandbox.py
@@ -23,7 +23,10 @@ import os
 from functools import wraps
 import numpy as np
 import tables
-from scipy.integrate import trapezoid
+try:
+    from scipy.integrate import trapezoid
+except ImportError:  # older scipy / numpy < 2.0
+    from scipy integrate import trapz as trapezoid
 
 from .simpletable import SimpleTable
 from .vega import Vega

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib
 astropy
 tables
 pandas
+setuptools


### PR DESCRIPTION
Scipy 1.14.0 (2024-06-24) removed `integrate.trapz` for `integrate.trapezoid` (matching numpy 2 API)

Default now imports `integrate.trapezoid` (#56), but falls back to the old import if necessary.

