### PR TITLE
Fixed broken link in example notebooks

### DIFF
--- a/examples/QuickStart.ipynb
+++ b/examples/QuickStart.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Some examples are provided in this notebook\n",
     "\n",
-    "Full documentation available at http://mfouesneau.github.io/docs/pyphot/"
+    "Full documentation available at https://mfouesneau.github.io/pyphot/"
    ]
   },
   {

--- a/examples/Sun_Vega.ipynb
+++ b/examples/Sun_Vega.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Some examples are provided in this notebook\n",
     "\n",
-    "Full documentation available at http://mfouesneau.github.io/docs/pyphot/"
+    "Full documentation available at https://mfouesneau.github.io/pyphot/"
    ]
   },
   {

--- a/examples/astropy_QuickStart.ipynb
+++ b/examples/astropy_QuickStart.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Some examples are provided in this notebook\n",
     "\n",
-    "Full documentation available at http://mfouesneau.github.io/docs/pyphot/"
+    "Full documentation available at https://mfouesneau.github.io/pyphot/"
    ]
   },
   {

--- a/examples/astropy_Sun_Vega.ipynb
+++ b/examples/astropy_Sun_Vega.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Some examples are provided in this notebook\n",
     "\n",
-    "Full documentation available at http://mfouesneau.github.io/docs/pyphot/"
+    "Full documentation available at https://mfouesneau.github.io/pyphot/"
    ]
   },
   {

--- a/examples/astropy_svo.ipynb
+++ b/examples/astropy_svo.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "Some examples are provided in this notebook\n",
     "\n",
-    "Full documentation available at http://mfouesneau.github.io/docs/pyphot/"
+    "Full documentation available at https://mfouesneau.github.io/pyphot/"
    ]
   },
   {

--- a/examples/sandbox_QuickStart.ipynb
+++ b/examples/sandbox_QuickStart.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Some examples are provided in this notebook\n",
     "\n",
-    "Full documentation available at http://mfouesneau.github.io/docs/pyphot/"
+    "Full documentation available at https://mfouesneau.github.io/pyphot/"
    ]
   },
   {

--- a/examples/sandbox_Sun_Vega.ipynb
+++ b/examples/sandbox_Sun_Vega.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "Some examples are provided in this notebook\n",
     "\n",
-    "Full documentation available at http://mfouesneau.github.io/docs/pyphot/"
+    "Full documentation available at https://mfouesneau.github.io/pyphot/"
    ]
   },
   {

--- a/examples/svo.ipynb
+++ b/examples/svo.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "Some examples are provided in this notebook\n",
     "\n",
-    "Full documentation available at http://mfouesneau.github.io/docs/pyphot/"
+    "Full documentation available at https://mfouesneau.github.io/pyphot/"
    ]
   },
   {


### PR DESCRIPTION
All the examples pointed to https://mfouesneau.github.io/docs/pyphot/ for more info, but that page does not exist any longer. The doc is on https://mfouesneau.github.io/pyphot/, so I changed all those obsolete links to that one.